### PR TITLE
Fix imu residual

### DIFF
--- a/include/robopt_open/common/definitions.h
+++ b/include/robopt_open/common/definitions.h
@@ -53,12 +53,12 @@ static const int kInverseDepthBlockSize = 1;
 static const int kPositionBlockSize = 3;
 static const int kPoseBlockSize = 7;
 
-// Specify in which direction the relative projection is perfomed. 
+// Specify in which direction the relative projection is perfomed.
 // kNormal: The optimized relative pose is directly used to transform points.
 // kInverse: The inversed relative pose is used to transform points.
 enum RelativeProjectionType {kNormal, kInverse};
 
-}; // namespace visual
+} // namespace visual
 
 namespace pose {
 
@@ -85,8 +85,8 @@ enum StateOrder {
   kBiasG = 12
 };
 
-}; // namespace pose
+} // namespace pose
 
-}; // namespace defs
+} // namespace defs
 
-}; // namespace robopt
+} // namespace robopt

--- a/src/imu-error/preintegration-base.cpp
+++ b/src/imu-error/preintegration-base.cpp
@@ -132,7 +132,15 @@ Eigen::Matrix<double, 15, 1> PreintegrationBase::evaluate(
       q_W_S1.inverse() *(0.5 * g_ * sum_dt_ * sum_dt_ + p_W_S2 - p_W_S1 -
       v_S1 * sum_dt_) - corrected_delta_p;
   Eigen::Vector3d rot_diff;
-  common::quaternion::Minus(q_W_S1.inverse()*q_W_S2, corrected_delta_q,
+  Eigen::Quaterniond q_S1_S2 = q_W_S1.inverse()*q_W_S2;
+  if (q_S1_S2.w() < 0) {
+    q_S1_S2.w() = -q_S1_S2.w();
+    q_S1_S2.x() = -q_S1_S2.x();
+    q_S1_S2.y() = -q_S1_S2.y();
+    q_S1_S2.z() = -q_S1_S2.z();
+  }
+
+  common::quaternion::Minus(q_S1_S2, corrected_delta_q,
       &rot_diff);
   residuals.block<3,1>(defs::pose::StateOrder::kRotation, 0) = rot_diff;
   residuals.block<3,1>(defs::pose::StateOrder::kVelocity, 0) =


### PR DESCRIPTION
This PR fixes problems in the visual inertial bundle adjustment of COVINS. Some IMU residuals encounter a large error due to a bug in the preintegration factor. The problem occurs when the real part of the quaternion representing the rotation between the pose of the current and previous time stamp is negative. 

This fix ensures that the real part is always positive by multiplying each value in the quaternion by -1 when the real part is negative. This is possible since **q** and -**q** represent the same rotation.